### PR TITLE
Frontend setup - Added Logout Functionality and optional SSR

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,8 +17,10 @@
     "framer-motion": "^6.3.0",
     "graphql": "^16.5.0",
     "next": "latest",
+    "next-urql": "^3.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-is": "^18.2.0",
     "urql": "^2.2.3"
   },
   "devDependencies": {

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -1,11 +1,12 @@
 import { Box, Button, Flex, Link, Text } from "@chakra-ui/react";
 import React from "react";
 import NextLink from "next/link";
-import { useMeQuery } from "../generated/graphql";
+import { useLogoutMutation, useMeQuery } from "../generated/graphql";
 
 interface NavBarProps {}
 
 export const NavBar: React.FC<NavBarProps> = ({}) => {
+  const [{ fetching: logoutFetching }, logout] = useLogoutMutation();
   const [{ data, fetching }] = useMeQuery();
   let body;
   if (fetching) {
@@ -25,7 +26,14 @@ export const NavBar: React.FC<NavBarProps> = ({}) => {
     body = (
       <Flex>
         <Box mr={4}>{data.me.username}</Box>
-        <Button variant="link" fontWeight={"normal"}>
+        <Button
+          onClick={() => {
+            logout();
+          }}
+          isLoading={logoutFetching}
+          variant="link"
+          fontWeight={"normal"}
+        >
           Logout
         </Button>
       </Flex>

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Flex, Link, Text } from "@chakra-ui/react";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import NextLink from "next/link";
 import { useLogoutMutation, useMeQuery } from "../generated/graphql";
 
@@ -7,8 +7,15 @@ interface NavBarProps {}
 
 export const NavBar: React.FC<NavBarProps> = ({}) => {
   const [{ fetching: logoutFetching }, logout] = useLogoutMutation();
-  const [{ data, fetching }] = useMeQuery();
-  let body;
+
+  const [serverStatus, setServerStatus] = useState(true);
+  useEffect(() => setServerStatus(false));
+
+  const [{ data, fetching }] = useMeQuery({
+    pause: serverStatus,
+  });
+
+  let body = null;
   if (fetching) {
   } else if (!data?.me) {
     body = (

--- a/client/src/generated/graphql.ts
+++ b/client/src/generated/graphql.ts
@@ -26,6 +26,7 @@ export type Mutation = {
   createPost: Post;
   deletePost: Scalars['Boolean'];
   login: UserResponse;
+  logout: Scalars['Boolean'];
   register: UserResponse;
   updatePost?: Maybe<Post>;
 };
@@ -106,6 +107,11 @@ export type LoginMutationVariables = Exact<{
 
 export type LoginMutation = { __typename?: 'Mutation', login: { __typename?: 'UserResponse', errors?: Array<{ __typename?: 'FieldError', field: string, message: string }> | null, user?: { __typename?: 'User', id: number, username: string } | null } };
 
+export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LogoutMutation = { __typename?: 'Mutation', logout: boolean };
+
 export type RegisterMutationVariables = Exact<{
   username: Scalars['String'];
   password: Scalars['String'];
@@ -141,6 +147,15 @@ export const LoginDocument = gql`
 
 export function useLoginMutation() {
   return Urql.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument);
+};
+export const LogoutDocument = gql`
+    mutation Logout {
+  logout
+}
+    `;
+
+export function useLogoutMutation() {
+  return Urql.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument);
 };
 export const RegisterDocument = gql`
     mutation Register($username: String!, $password: String!) {

--- a/client/src/generated/graphql.ts
+++ b/client/src/generated/graphql.ts
@@ -125,6 +125,11 @@ export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type MeQuery = { __typename?: 'Query', me?: { __typename?: 'User', id: number, username: string } | null };
 
+export type PostsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type PostsQuery = { __typename?: 'Query', posts: Array<{ __typename?: 'Post', id: number, createdAt: string, updatedAt: string, title: string }> };
+
 export const RegularUserFragmentDoc = gql`
     fragment RegularUser on User {
   id
@@ -184,4 +189,18 @@ export const MeDocument = gql`
 
 export function useMeQuery(options?: Omit<Urql.UseQueryArgs<MeQueryVariables>, 'query'>) {
   return Urql.useQuery<MeQuery, MeQueryVariables>({ query: MeDocument, ...options });
+};
+export const PostsDocument = gql`
+    query Posts {
+  posts {
+    id
+    createdAt
+    updatedAt
+    title
+  }
+}
+    `;
+
+export function usePostsQuery(options?: Omit<Urql.UseQueryArgs<PostsQueryVariables>, 'query'>) {
+  return Urql.useQuery<PostsQuery, PostsQueryVariables>({ query: PostsDocument, ...options });
 };

--- a/client/src/graphql/mutations/logout.graphql
+++ b/client/src/graphql/mutations/logout.graphql
@@ -1,0 +1,3 @@
+mutation Logout {
+  logout
+}

--- a/client/src/graphql/queries/posts.graphql
+++ b/client/src/graphql/queries/posts.graphql
@@ -1,0 +1,8 @@
+query Posts {
+  posts {
+    id
+    createdAt
+    updatedAt
+    title
+  }
+}

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,70 +1,13 @@
 import { ChakraProvider } from "@chakra-ui/react";
-import { createClient, dedupExchange, fetchExchange, Provider } from "urql";
-import { cacheExchange, Cache, UpdatesConfig } from "@urql/exchange-graphcache";
 
-import theme from "../theme";
 import { AppProps } from "next/app";
-import {
-  LoginMutation,
-  LogoutMutation,
-  MeDocument,
-  MeQuery,
-  RegisterMutation,
-} from "../generated/graphql";
-
-const client = createClient({
-  url: "http://localhost:4000/graphql",
-  fetchOptions: {
-    credentials: "include",
-  },
-  exchanges: [
-    dedupExchange,
-    cacheExchange({
-      updates: {
-        Mutation: {
-          login: (result: LoginMutation, args, cache, info) => {
-            cache.updateQuery({ query: MeDocument }, (data: MeQuery | null) => {
-              if (result.login.errors) {
-                return data;
-              } else {
-                return {
-                  me: result.login.user,
-                };
-              }
-            });
-          },
-          register: (result: RegisterMutation, args, cache, info) => {
-            cache.updateQuery({ query: MeDocument }, (data: MeQuery | null) => {
-              if (result.register.errors) {
-                return data;
-              } else {
-                return {
-                  me: result.register.user,
-                };
-              }
-            });
-          },
-          logout: (result: LogoutMutation, args, cache, infor) => {
-            cache.updateQuery({ query: MeDocument }, (data: MeQuery | null) => {
-              return {
-                me: null,
-              };
-            });
-          },
-        },
-      },
-    }),
-    fetchExchange,
-  ],
-});
+import theme from "../theme";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <Provider value={client}>
-      <ChakraProvider theme={theme}>
-        <Component {...pageProps} />
-      </ChakraProvider>
-    </Provider>
+    <ChakraProvider theme={theme}>
+      <Component {...pageProps} />
+    </ChakraProvider>
   );
 }
 

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import theme from "../theme";
 import { AppProps } from "next/app";
 import {
   LoginMutation,
+  LogoutMutation,
   MeDocument,
   MeQuery,
   RegisterMutation,
@@ -41,6 +42,13 @@ const client = createClient({
                   me: result.register.user,
                 };
               }
+            });
+          },
+          logout: (result: LogoutMutation, args, cache, infor) => {
+            cache.updateQuery({ query: MeDocument }, (data: MeQuery | null) => {
+              return {
+                me: null,
+              };
             });
           },
         },

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,15 +1,25 @@
+import { withUrqlClient } from "next-urql";
 import React from "react";
 import { NavBar } from "../components/NavBar";
+import { usePostsQuery } from "../generated/graphql";
+import { createUrqlClient } from "../utils/createUrqlClient";
 
 interface indexProps {}
 
 const index: React.FC<indexProps> = ({}) => {
+  const [{ data }] = usePostsQuery();
   return (
     <>
       <NavBar />
       <div>Hello there</div>
+      <br />
+      {!data ? (
+        <div>loading...</div>
+      ) : (
+        data.posts.map((p) => <div key={p.id}>{p.title}</div>)
+      )}
     </>
   );
 };
 
-export default index;
+export default withUrqlClient(createUrqlClient, { ssr: true })(index);

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -6,6 +6,8 @@ import { InputField } from "../components/InputField";
 import { useLoginMutation } from "../generated/graphql";
 import { toErrorMap } from "../utils/toErrorMap";
 import { useRouter } from "next/router";
+import { withUrqlClient } from "next-urql";
+import { createUrqlClient } from "../utils/createUrqlClient";
 
 interface loginProps {}
 
@@ -50,4 +52,5 @@ const Login: React.FC<loginProps> = ({}) => {
   );
 };
 
-export default Login;
+//  no ssr
+export default withUrqlClient(createUrqlClient)(Login);

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -6,6 +6,8 @@ import { InputField } from "../components/InputField";
 import { useRegisterMutation } from "../generated/graphql";
 import { toErrorMap } from "../utils/toErrorMap";
 import { useRouter } from "next/router";
+import { withUrqlClient } from "next-urql";
+import { createUrqlClient } from "../utils/createUrqlClient";
 
 interface registerProps {}
 
@@ -50,4 +52,4 @@ const Register: React.FC<registerProps> = ({}) => {
   );
 };
 
-export default Register;
+export default withUrqlClient(createUrqlClient)(Register);

--- a/client/src/utils/createUrqlClient.ts
+++ b/client/src/utils/createUrqlClient.ts
@@ -1,0 +1,56 @@
+import { dedupExchange, fetchExchange } from "urql";
+import { cacheExchange } from "@urql/exchange-graphcache";
+import {
+  LoginMutation,
+  MeDocument,
+  MeQuery,
+  RegisterMutation,
+  LogoutMutation,
+} from "../generated/graphql";
+
+export const createUrqlClient = (ssrExchange: any) => ({
+  url: "http://localhost:4000/graphql",
+  fetchOptions: {
+    credentials: "include" as const,
+  },
+  exchanges: [
+    dedupExchange,
+    cacheExchange({
+      updates: {
+        Mutation: {
+          login: (result: LoginMutation, args, cache, info) => {
+            cache.updateQuery({ query: MeDocument }, (data: MeQuery | null) => {
+              if (result.login.errors) {
+                return data;
+              } else {
+                return {
+                  me: result.login.user,
+                };
+              }
+            });
+          },
+          register: (result: RegisterMutation, args, cache, info) => {
+            cache.updateQuery({ query: MeDocument }, (data: MeQuery | null) => {
+              if (result.register.errors) {
+                return data;
+              } else {
+                return {
+                  me: result.register.user,
+                };
+              }
+            });
+          },
+          logout: (result: LogoutMutation, args, cache, infor) => {
+            cache.updateQuery({ query: MeDocument }, (data: MeQuery | null) => {
+              return {
+                me: null,
+              };
+            });
+          },
+        },
+      },
+    }),
+    ssrExchange,
+    fetchExchange,
+  ],
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3379,6 +3379,13 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+next-urql@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/next-urql/-/next-urql-3.3.3.tgz#3eda3e57c0a51955deba7fd4fba250fc88846874"
+  integrity sha512-mKdpbvxW7FifHjupRKNjE1YuZxhLF+GlN/y1sARcUSEdrCv10dRkFGQl03p4UpWtdggCyZ5lOVBBaQGW7UNfiQ==
+  dependencies:
+    react-ssr-prepass "^1.4.0"
+
 next@latest:
   version "12.2.3"
   resolved "https://registry.yarnpkg.com/next/-/next-12.2.3.tgz#c29d235ce480e589894dfab3120dade25d015a22"
@@ -3725,6 +3732,11 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-remove-scroll-bar@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.3.tgz#e291f71b1bb30f5f67f023765b7435f4b2b2cd94"
@@ -3743,6 +3755,11 @@ react-remove-scroll@^2.5.4:
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
+
+react-ssr-prepass@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.5.0.tgz#bc4ca7fcb52365e6aea11cc254a3d1bdcbd030c5"
+  integrity sha512-yFNHrlVEReVYKsLI5lF05tZoHveA5pGzjFbFJY/3pOqqjGOmMmqx83N4hIjN2n6E1AOa+eQEUxs3CgRnPmT0RQ==
 
 react-style-singleton@^2.2.1:
   version "2.2.1"

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -4,3 +4,4 @@ dotenv.config();
 export const __dbuser__ = "shreyash";
 export const __dbpass__ = process.env.DB_PASS;
 export const __prod__ = process.env.NODE_ENV === "production";
+export const COOKIE_NAME = "qid";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,7 +12,7 @@ import { buildSchema } from "type-graphql";
 import { HelloResolver } from "./resolvers/hello";
 import { PostResolver } from "./resolvers/post";
 import { UserResolver } from "./resolvers/user";
-import { __prod__ } from "./constants";
+import { COOKIE_NAME, __prod__ } from "./constants";
 import { MyContext } from "./types";
 
 declare module "express-session" {
@@ -40,7 +40,7 @@ const main = async () => {
 
   app.use(
     session({
-      name: "qid",
+      name: COOKIE_NAME,
       store: new RedisStore({
         client: redisClient,
         disableTouch: true,

--- a/server/src/resolvers/user.ts
+++ b/server/src/resolvers/user.ts
@@ -1,5 +1,5 @@
 import { User } from "../entities/User";
-import { MyContext } from "src/types";
+import { MyContext } from "../types";
 import {
   Resolver,
   Mutation,
@@ -11,6 +11,7 @@ import {
   Query,
 } from "type-graphql";
 import argon2 from "argon2";
+import { COOKIE_NAME } from "../constants";
 
 @InputType()
 class UsernamePasswordInput {
@@ -135,5 +136,21 @@ export class UserResolver {
     req.session.userId = user.id;
 
     return { user };
+  }
+
+  @Mutation(() => Boolean)
+  logout(@Ctx() { req, res }: MyContext) {
+    return new Promise((_res) =>
+      req.session.destroy((err) => {
+        if (err) {
+          console.log(err);
+          _res(false);
+          return;
+        }
+
+        res.clearCookie(COOKIE_NAME); //  clears cookie on browser
+        _res(true);
+      })
+    );
   }
 }


### PR DESCRIPTION
Day Seven - August 3, 2022

Added a Logout resolver which deletes the session and deltes all "Qid" cookies in the browser.
In the frontend, created a useLogoutMutation hook using yarn gen.
Added that in Navbar.
Updated graphcache on every logout mutation to {me: null}

Day 8 - August 04, 2022

Added next-urql and react-is.
Didnt add isomorphic fetch because the docs say that it's not required.
Created a util in client which createsUrqlClient and enables optional server side rendering.
Created a util in server to sleep

SSR should only be done if you have something that you want google to notice --- SEO

Tried adding a piece of code to not call me queries on navbar until we are on browser.
//
ERROR

Hydration Error -> this occurred because of difference between server render and browser render caused due to "window === undefined"
Solution ->

Best way to check window === "undefined", useEffect only occurs when window = true.
const [serverStatus, setServerStatus] = useState(true);
useEffect(() => setServerStatus(false));
//

